### PR TITLE
Update minimum Json version

### DIFF
--- a/shippo.gemspec
+++ b/shippo.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata              = { 'shippo_documentation' => 'https://goshippo.com/docs/' }
 
   spec.add_dependency 'rest-client', '>= 2.0', '<2.2'
-  spec.add_dependency 'json', '~> 1.8'
+  spec.add_dependency 'json', '~> 2.1'
   spec.add_dependency 'hashie', '>= 3.5.2'
   spec.add_dependency 'activesupport', '>= 4'
   spec.add_dependency 'awesome_print'


### PR DESCRIPTION
This is needed because the container that our serverless version of the app runs inside already has a version of the JSON gem and it conflicts with the one that was required by the shippo client. We have asked them to update their client. Hopefully this will do this soon and we can go back to using the standard client.